### PR TITLE
remove versioned normdatei from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ lxml==4.1.1
 Mako==1.0.7
 MarkupSafe==1.0
 normality==0.5.6
-normdatei==0.2
 parse==1.8.2
 psycopg2==2.7.3.2
 python-dateutil==2.6.1


### PR DESCRIPTION
version 0.2 is not actually published on PyPi but only available
in our fork on github.
This needs to be unpinned so that install and travis do not fail